### PR TITLE
OpenAPI di interoperabilita' FO-BO-ET

### DIFF
--- a/OpenAPI/bo_to_et.yaml
+++ b/OpenAPI/bo_to_et.yaml
@@ -428,7 +428,7 @@ components:
                     type: string
                 outcome_motivation:
                     type: string
-                    title: la motivazione della conclusione. In caso di outcome negativo, ne descrive il motivo. In caso di conformazione, indica anche la data entro cui effettuarla.
+                    title: la motivazione della conclusione. In caso di outcome negativo o di conformazione, ne descrive il motivo.
                 requester_administration:
                     title: amministrazione richiedente
                     $ref: "#/components/schemas/AdministrationSchema"
@@ -447,6 +447,10 @@ components:
                     - S256
                     - S384
                     - S512
+                date_conformation:
+                    title: data entro cui effettuare la conformazione, se la conclusion type e' una conformazione.
+                    type: string
+                    format: date
             example:
                 conclusions_type: "conclusione per conformazione"
                 cui: 

--- a/OpenAPI/bo_to_fo.yaml
+++ b/OpenAPI/bo_to_fo.yaml
@@ -48,6 +48,7 @@ paths:
                                         - resource_id
                                         - hash
                                         - alg_hash
+                                        - description
                                         properties:
                                             resource_id:                            
                                                 title: id della risorsa, univoco per erogatore e CUI.UUID
@@ -64,6 +65,10 @@ paths:
                                                 - S256
                                                 - S384
                                                 - S512
+                                            description:                            
+                                                title: descrizione della risorsa
+                                                type: string
+                                                minLength: 1
                                
                 required: true
             responses:

--- a/OpenAPI/et_to_bo.yaml
+++ b/OpenAPI/et_to_bo.yaml
@@ -357,6 +357,8 @@ components:
                 event:
                     type: string
                     enum:
+                        - end_by_proceeding_time_expired
+                        - end_by_integration_times_expired
                         - end_by_submitter_cancel_requested
                         - integration_request_time_expired
                         

--- a/OpenAPI/fo_to_bo.yaml
+++ b/OpenAPI/fo_to_bo.yaml
@@ -448,6 +448,8 @@ components:
                     type: string
                     enum:
                         - end_by_instance_refused
+                        - end_by_proceeding_time_expired
+                        - end_by_integration_times_expired
                         - end_by_submitter_cancel_requested
                         - cdss_convened
 
@@ -485,6 +487,10 @@ components:
                     - S256
                     - S384
                     - S512
+                date_conformation:
+                    title: data entro cui effettuare la conformazione, se la conclusion type e' una conformazione.
+                    type: string
+                    format: date
 
     headers:
         Agid-JWT-Signature:


### PR DESCRIPTION
Modifica delle open API di scambio tra le componenti informatiche SUE (senza numero di protocollo).

Changelog:

**bo_to_et.yaml**

- Modificato il SendConclusionRequests rimuovendo le tipologie di Outcome, per lasciarne una generica. I campi required sono: cui, instance_descriptor_version, conclusions_type, requester_administration. Il campo conclusions_type è stato reso una stringa, nella quale l'operatore deve specificare la tipologia della conclusione. Abbiamo aggiunto il campo opzionale outcome_motivation per permettere all'operatore di specificare la motivazione della conclusione. In caso di outcome negativo, ne descrive il motivo. In caso di conformazione, indica anche la data entro cui effettuarla.

**et_to_bo.yaml**

- Rimosso il GeneralIndex
- Ridotto gli eventi della NotifyMessage ai seguenti: end_by_submitter_cancel_requested, integration_request_time_expired
- Ridotto gli eventi della TransferOutcomeNotifyMessage al seguente generico: end_by_conclusion
- Aggiunto alla TransferOutcomeNotifyMessage il parametro obbligatorio di tipo stringa: conclusions_type

**fo_to_bo.yaml**

- Ridotto gli eventi della NotifyMessage ai seguenti: end_by_instance_refused, end_by_submitter_cancel_requested, cdss_convened
- Ridotto gli eventi della TransferOutcomeNotifyMessage al seguente generico: end_by_conclusion
- Aggiunto alla TransferOutcomeNotifyMessage il parametro obbligatorio di tipo stringa: conclusions_type

**bo_to_fo.yaml**

- Rimosso il GeneralIndex
- Sostituito nel /notify_receipt il "general_index" con la nuova property facoltativa "resources", di tipo array di objects di risorse generico
