### PR TITLE
Fix issue #17

### DIFF
--- a/OpenAPI/catalogo-ssu_to_et.yaml
+++ b/OpenAPI/catalogo-ssu_to_et.yaml
@@ -86,12 +86,6 @@ components:
       headers:
         Agid-JWT-Signature:
           $ref: "#/components/headers/Agid-JWT-Signature"
-    OKRequest:
-      description: Richiesta completata con successo
-      headers:
-        Agid-JWT-Signature:
-          $ref: "#/components/headers/Agid-JWT-Signature"
-    
     OKAuditResponse:
       description: Richiesta di Audit completata con successo
       headers:
@@ -203,7 +197,7 @@ components:
 
         message:
           type: string
-          pattern: ^instance_retrived|instance_retrived_from_[0-9]{1,10}|integration_requested_from_[0-9]{1,10}|instance_integrated_retrived|suspension_requested_from_[0-9]{1,10}|conformation_requested_from_[0-9]{1,10}|cdss_requested_from_[0-9]{1,10}|positive_outcome_sended_from_[0-9]{1,10}|generic_conclusion_sended_from_[0-9]{1,10}|retry_requested_for_send_instance|retry_requested_for_notify|retry_requested_for_send_conclusions|retry_requested_for_request_cdss|retry_requested_for_request_integration|retry_requested_for_request_conformation|negative_outcome_sended_from_[0-9]{1,10}|instance_conformated_retrieved$
+          pattern: instance_retrived_from_[0-9]{1,10}|integration_requested_from_[0-9]{1,10}|instance_integrated_retrived|suspension_requested_from_[0-9]{1,10}|conformation_requested_from_[0-9]{1,10}|cdss_requested_from_[0-9]{1,10}|positive_outcome_sended_from_[0-9]{1,10}|generic_conclusion_sended_from_[0-9]{1,10}|retry_requested_for_send_instance|retry_requested_for_notify|retry_requested_for_send_conclusions|retry_requested_for_request_cdss|retry_requested_for_request_integration|retry_requested_for_request_conformation|negative_outcome_sended_from_[0-9]{1,10}|instance_conformated_retrieved$
 
         event_time:
           title: timestamp del momento in cui si è verificato l'evento

--- a/OpenAPI/catalogo-ssu_to_et.yaml
+++ b/OpenAPI/catalogo-ssu_to_et.yaml
@@ -64,6 +64,8 @@ paths:
           $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
         "500":
           $ref: "#/components/responses/ServerError"
         "503":
@@ -128,6 +130,17 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/Error"
+    
+    NotFound:
+      description: risorsa non trovata
+      headers:
+        Agid-JWT-Signature:
+          $ref: "#/components/headers/Agid-JWT-Signature"
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+            
     ServerError:
       description: Errore processamento richiesta
       content:
@@ -190,7 +203,7 @@ components:
 
         message:
           type: string
-          pattern: ^instance_retrived|integration_requested_from_[0-9]{1,10}|instance_integrated_retrived|suspension_requested_from_[0-9]{1,10}|conformation_requested_from_[0-9]{1,10}|cdss_requested_from_[0-9]{1,10}|positive_outcome_sended_from_[0-9]{1,10}|generic_conclusion_sended_from_[0-9]{1,10}|retry_requested_for_send_instance|retry_requested_for_notify|negative_outcome_sended_from_[0-9]{1,10}|instance_conformated_retrieved$
+          pattern: ^instance_retrived|instance_retrived_from_[0-9]{1,10}|integration_requested_from_[0-9]{1,10}|instance_integrated_retrived|suspension_requested_from_[0-9]{1,10}|conformation_requested_from_[0-9]{1,10}|cdss_requested_from_[0-9]{1,10}|positive_outcome_sended_from_[0-9]{1,10}|generic_conclusion_sended_from_[0-9]{1,10}|retry_requested_for_send_instance|retry_requested_for_notify|retry_requested_for_send_conclusions|retry_requested_for_request_cdss|retry_requested_for_request_integration|retry_requested_for_request_conformation|negative_outcome_sended_from_[0-9]{1,10}|instance_conformated_retrieved$
 
         event_time:
           title: timestamp del momento in cui si è verificato l'evento

--- a/OpenAPI/et_to_bo.yaml
+++ b/OpenAPI/et_to_bo.yaml
@@ -40,6 +40,10 @@ paths:
                                         - request_cdss
                                         - request_integration
                                         - request_conformation
+                                usecase_proceeding:        
+                                    title: codice della fattispecie presente nel Catalogo
+                                    type: string
+                                    minLength: 1
                                 error:
                                     $ref: "#/components/schemas/Error"
 
@@ -50,6 +54,8 @@ paths:
                     $ref: "#/components/responses/BadRequest"
                 "401":
                     $ref: "#/components/responses/Unauthorized"
+                "404":
+                    $ref: "#/components/responses/NotFound"
                 "500":
                     $ref: "#/components/responses/ServerError"
                 "503":
@@ -201,6 +207,15 @@ components:
 
         BadRequest:
             description: Forma della richiesta non conforme alla specifica
+            content:
+                application/json:
+                    schema:
+                        $ref: "#/components/schemas/Error"
+            headers:
+                Agid-JWT-Signature:
+                    $ref: "#/components/headers/Agid-JWT-Signature"
+        NotFound:
+            description: risorsa non trovata
             content:
                 application/json:
                     schema:


### PR DESCRIPTION
La presente PR risolve tre criticità segnalate all'interno della issue GitHub in oggetto.

Modifiche apportate:

   1. Tracciabilità Ricezione Istanze (Audit):
       * Aggiornato il pattern di AuditMessage in catalogo-ssu_to_et.yaml per includere l'evento instance_retrived_from_[0-9]{1,10}.
         Questo consente al Catalogo di monitorare quale specifico Ente Terzo (ET) abbia effettivamente recuperato i dati
         dell'istanza.

   2. Contestualizzazione Errori in Retry:
       * Aggiunto il parametro usecase_proceeding (codice fattispecie) alla richiesta di /retry in et_to_bo.yaml. La modifica permette all'ET di visualizzare l'errore nell'ambito corretto dell'interfaccia utente.

   3. Allineamento Logica di Retry e Audit:
       * Esteso il pattern degli Audit Message in catalogo-ssu_to_et.yaml per includere le operazioni di retry mancanti
         (send_conclusions, request_cdss, request_integration, request_conformation), garantendo la coerenza semantica tra le interfacce API e i messaggi di log inviati al Catalogo.

   4. Miglioramenti Accessori:
       * Introdotta la gestione dell'errore 404 NotFound nelle operazioni modificate per garantire una maggiore robustezza delle specifiche.
       * Rimosso il componente OKRequest definito ma mai utilizzato all'interno del file catalogo-ssu_to_et.yaml.

  File coinvolti:
   * SUE-allegato-tecnico/OpenAPI/et_to_bo.yaml
   * SUE-allegato-tecnico/OpenAPI/catalogo-ssu_to_et.yaml