### PR TITLE
Porting della Classificazione Documentale e gestione Tag su Catalogo Meta e RI-to-BO 

### DIFF
--- a/OpenAPI/catalogo-ssu_meta.yaml
+++ b/OpenAPI/catalogo-ssu_meta.yaml
@@ -1158,7 +1158,7 @@ paths:
             type: array
             items:
               type: string
-              maxItems: 50
+            maxItems: 50
           style: simple
         - in: path
           name: context
@@ -1278,7 +1278,7 @@ paths:
             type: array
             items:
               type: string
-              maxItems: 50
+            maxItems: 50
           style: simple
 
       responses:
@@ -1326,7 +1326,7 @@ paths:
             type: array
             items:
               type: string
-              maxItems: 50
+            maxItems: 50
           style: simple
     
       responses:
@@ -1385,7 +1385,7 @@ paths:
             type: array
             items:
               type: string
-              maxItems: 50
+            maxItems: 50
           style: simple
 
       responses:
@@ -1443,7 +1443,7 @@ paths:
             type: array
             items:
               type: string
-              maxItems: 50
+            maxItems: 50
           style: simple
     
       responses:
@@ -1502,7 +1502,7 @@ paths:
             type: array
             items:
               type: string
-              maxItems: 50
+            maxItems: 50
           style: simple
         - in: path
           name: context
@@ -1566,7 +1566,7 @@ paths:
             type: array
             items:
               type: string
-              maxItems: 50
+            maxItems: 50
           style: simple
   
       responses:
@@ -1623,7 +1623,7 @@ paths:
             type: array
             items:
               type: string
-              maxItems: 50
+            maxItems: 50
           style: simple
     
 
@@ -1681,7 +1681,7 @@ paths:
             type: array
             items:
               type: string
-              maxItems: 50
+            maxItems: 50
           style: simple
     
       responses:
@@ -1737,7 +1737,7 @@ paths:
             type: array
             items:
               type: string
-              maxItems: 50
+            maxItems: 50
           style: simple
       
       responses:
@@ -1805,7 +1805,7 @@ paths:
             type: array
             items:
               type: string
-              maxItems: 50
+            maxItems: 50
           style: simple
 
       responses:
@@ -1864,7 +1864,7 @@ paths:
             type: array
             items:
               type: string
-              maxItems: 50
+            maxItems: 50
           style: simple
 
       responses:
@@ -1920,7 +1920,7 @@ paths:
             type: array
             items:
               type: string
-              maxItems: 50
+            maxItems: 50
           style: simple
         - in: path
           name: context
@@ -1982,7 +1982,7 @@ paths:
             type: array
             items:
               type: string
-              maxItems: 50
+            maxItems: 50
           style: simple
         
       responses:
@@ -2035,7 +2035,7 @@ paths:
             type: array
             items:
               type: string
-              maxItems: 50
+            maxItems: 50
           style: simple
       
       responses:
@@ -2091,7 +2091,7 @@ paths:
             type: array
             items:
               type: string
-              maxItems: 50
+            maxItems: 50
           style: simple
       
       responses:

--- a/OpenAPI/catalogo-ssu_meta.yaml
+++ b/OpenAPI/catalogo-ssu_meta.yaml
@@ -71,25 +71,70 @@ paths:
       tags:
         - Context
 
+  /tags:
+    get:
+      description: Recupero dei possibili valori del contesto di riferimento
+
+      responses:
+        "200":
+          description: Elenco dei possibili valori dei tag dei procedimenti
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  required:
+                    - tag
+                    - description
+                  properties:
+                    tag:
+                      title: id del tag
+                      type: string
+                    description:
+                      title: descrizione del tag
+                      type: string
+          headers:
+            Agid-JWT-Signature:
+              $ref: "#/components/headers/Agid-JWT-Signature"
+
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/ServerError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+
+      security:
+        - bearerAuth: []
+          Agid-JWT-Signature: []
+
+      tags:
+        - Tags
+
   /typologies-lifeevents/{context}:
     get:
       description: Recupero elenco tipologie ed eventi della vita dei procedimenti
       parameters:
         - in: query
           name: typology
-          description: paramentro di filtering sulla tipologia richiesta, non valorizzato per richiedere l'intero set
+          description: parametro di filtering sulla tipologia richiesta, non valorizzato per richiedere l'intero set
           required: false
           schema:
             type: string
         - name: lifeevent
           in: query
-          description: paramentro di filtering su gli eventi della vita, non valorizzato per richiedere l'intero set
-          required: true
+          description: parametro di filtering sugli eventi della vita, non valorizzato per richiedere l'intero set
+          required: false
           schema:
             type: string
         - name: municipality
           in: query
-          description: paramentro di filtering sul comune richiesto, non valorizzato per richiedere l'intero set
+          description: parametro di filtering sul comune richiesto, non valorizzato per richiedere l'intero set
           required: false
           schema:
             type: string
@@ -126,7 +171,7 @@ paths:
                       description: identificativo del comune per cui la coppia  {typology,lifeevent} esiste per almeno un procedimento afferente afferente al comune
                       type: string
                     context:
-                      description: contesto di riferimento (es. SUAP, SUE)
+                      description: contesto di riferimento (es. SUAP, SUE, ZES)
                       type: string
 
           headers:
@@ -264,6 +309,211 @@ paths:
 
       tags:
         - Proceedings
+
+  /document_classifications:
+    get:
+      description: |
+        Recupero di tutte le classificazioni che possono essere associate ai documenti secondo la Tassonomia in Allegato A - Art.5 comma 1 Decreto 17 settembre 2024 n.159 ss.mm.ii.
+
+      parameters:
+        - name: coding
+          in: query  
+          description: Codifica della classificazione associata ad un documento
+          required: false
+          schema:
+            type: string
+            pattern: "C[0-9]{1,2}_[a-z]"
+        - name: class_code
+          in: query  
+          description: Codice della Classe di un documento
+          required: false
+          schema:
+            type: string
+            pattern: "C[0-9]{1,2}"
+        - name: class_description
+          in: query  
+          description: Descrizione della Classe di un documento
+          required: false
+          schema:
+            type: string
+        - name: typology_code
+          in: query  
+          description: Codice della Tipologia di un documento
+          required: false
+          schema:
+            type: string
+            pattern: "[a-z]"
+        - name: typology_description
+          in: query  
+          description: Descrizione della Tipologia di un documento
+          required: false
+          schema:
+            type: string
+
+      responses:
+        "200":
+          description: Elenco delle classificazioni che possono essere associate ai documenti.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/DocumentClassification"
+
+          headers:
+            Agid-JWT-Signature:
+              $ref: "#/components/headers/Agid-JWT-Signature"
+
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/ServerError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+
+      security:
+        - bearerAuth: []
+          Agid-JWT-Signature: []
+
+      tags:
+        - Classifications
+
+  /general_index_classifications/{name}:
+    get:
+      description: |
+        Recupero della classificazione associata ad un documento del General-Index, secondo la Tassonomia in Allegato A - Art.5 comma 1 Decreto 17 settembre 2024 n.159 ss.mm.ii.
+
+      parameters:
+        - name: name
+          in: path  
+          description: Nome del documento gestito nel General-Index
+          required: true
+          schema:
+            type: string
+
+      responses:
+        "200":
+          description: Elenco delle classificazioni che possono essere associate ai documenti.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DocumentClassification"
+
+          headers:
+            Agid-JWT-Signature:
+              $ref: "#/components/headers/Agid-JWT-Signature"
+
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/ServerError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+
+      security:
+        - bearerAuth: []
+          Agid-JWT-Signature: []
+
+      tags:
+        - Classifications
+
+  /document_classification/form/{form_id_list}:
+    get:
+      description: |
+        Recupero della classificazione associata ai documenti di tipo Form secondo la Tassonomia in Allegato A - Art.5 comma 1 Decreto 17 settembre 2024 n.159 ss.mm.ii.
+
+      parameters:
+        - name: form_id_list
+          in: path
+          description: lista di id associati ai form
+          required: true
+          schema:
+              type: string
+
+      responses:
+        "200":
+          description: Elenco dei documenti classificati
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/DocumentEntityClassified"
+
+          headers:
+            Agid-JWT-Signature:
+              $ref: "#/components/headers/Agid-JWT-Signature"
+
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/ServerError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+
+      security:
+        - bearerAuth: []
+          Agid-JWT-Signature: []
+
+      tags:
+        - Classifications
+
+  /document_classification/attachment/{attachment_id_list}:
+    get:
+      description: |
+        Recupero della classificazione associata ai documenti di tipo Attachment secondo la Tassonomia in Allegato A - Art.5 comma 1 Decreto 17 settembre 2024 n.159 ss.mm.ii.
+
+      parameters:
+        - name: attachment_id_list
+          in: path
+          description: lista di id associati agli attachment
+          required: true
+          schema:
+              type: string
+
+      responses:
+        "200":
+          description: Elenco dei documenti classificati
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/DocumentEntityClassified"
+
+          headers:
+            Agid-JWT-Signature:
+              $ref: "#/components/headers/Agid-JWT-Signature"
+
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/ServerError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+
+      security:
+        - bearerAuth: []
+          Agid-JWT-Signature: []
+
+      tags:
+        - Classifications
 
   /proceeding/{proceeding_id}/{proceeding_version}/attachments:
     get:
@@ -449,7 +699,6 @@ paths:
           schema:
             type: string
             pattern: "[0-9]{2}.[0-9]{2}.[0-9]{2}"
-        
       responses:
         "200":
           description: Elenco delle fattispecie relazionate alla fattispecie richiesta
@@ -690,7 +939,7 @@ paths:
 
       tags:
         - Attachments
- 
+        
   /competent-administration/{competent_administration_ipacode}/{competent_administration_code}/{competent_administration_version}/third-party-system:
     get:
       description: |
@@ -909,6 +1158,7 @@ paths:
             type: array
             items:
               type: string
+              maxItems: 50
           style: simple
         - in: path
           name: context
@@ -949,6 +1199,71 @@ paths:
 
       tags:
         - Bulk
+        
+  /proceedings-by-municipality/{municipality_list}/{context}/{tags}:
+    get:
+      description: |
+        Recupero bulk elenco procedimenti(tutte le versioni) per una lista di comuni
+      parameters:
+        - in: path
+          name: municipality_list
+          description: elenco dei comuni per le quali la risorsa è richiesta
+          required: true
+          schema: 
+            type: array
+            items:
+              type: string
+            maxItems: 50
+          style: simple
+        - in: path
+          name: context
+          description: contesto di riferimento. I valori ammissibili sono reperibili invocando il path /context
+          required: true
+          schema:
+            type: string
+            default: "SUAP"
+        - in: path
+          name: tags
+          description: elenco dei tag per i quali la risorsa è richiesta
+          required: true
+          schema: 
+            type: array
+            items:
+              type: string
+            maxItems: 50
+          style: simple            
+
+      responses:
+        "200":
+          description: Elenco dei procedimenti richiesti
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Proceeding"
+
+          headers:
+            Agid-JWT-Signature:
+              $ref: "#/components/headers/Agid-JWT-Signature"
+
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/ServerError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+
+      security:
+        - bearerAuth: []
+          Agid-JWT-Signature: []
+
+      tags:
+        - Bulk        
 
   /proceedings-by-id/{id_proceeding_list}:
     get:
@@ -963,6 +1278,7 @@ paths:
             type: array
             items:
               type: string
+              maxItems: 50
           style: simple
 
       responses:
@@ -1010,6 +1326,7 @@ paths:
             type: array
             items:
               type: string
+              maxItems: 50
           style: simple
     
       responses:
@@ -1068,6 +1385,7 @@ paths:
             type: array
             items:
               type: string
+              maxItems: 50
           style: simple
 
       responses:
@@ -1125,6 +1443,7 @@ paths:
             type: array
             items:
               type: string
+              maxItems: 50
           style: simple
     
       responses:
@@ -1183,6 +1502,7 @@ paths:
             type: array
             items:
               type: string
+              maxItems: 50
           style: simple
         - in: path
           name: context
@@ -1246,6 +1566,7 @@ paths:
             type: array
             items:
               type: string
+              maxItems: 50
           style: simple
   
       responses:
@@ -1302,6 +1623,7 @@ paths:
             type: array
             items:
               type: string
+              maxItems: 50
           style: simple
     
 
@@ -1359,6 +1681,7 @@ paths:
             type: array
             items:
               type: string
+              maxItems: 50
           style: simple
     
       responses:
@@ -1414,6 +1737,7 @@ paths:
             type: array
             items:
               type: string
+              maxItems: 50
           style: simple
       
       responses:
@@ -1430,7 +1754,7 @@ paths:
                     - competent_administration
                     - municipality
                   properties:
-                    primary:
+                    proceeding:
                       $ref: "#/components/schemas/ContextEntity"
                     competent_administration:
                       $ref: "#/components/schemas/GenericEntity"
@@ -1481,6 +1805,7 @@ paths:
             type: array
             items:
               type: string
+              maxItems: 50
           style: simple
 
       responses:
@@ -1539,8 +1864,9 @@ paths:
             type: array
             items:
               type: string
+              maxItems: 50
           style: simple
-      
+
       responses:
         "200":
           description: Elenco tuple {amministrazione competente,sistema ente terzo} richiesto
@@ -1555,7 +1881,7 @@ paths:
                     - third_party_system
                   properties:
                     competent_administration:
-                      $ref: "#/components/schemas/ComponentEntity"
+                      $ref: "#/components/schemas/AdministrationEntity"
                     third_party_system:
                       $ref: "#/components/schemas/third_party_system"
               
@@ -1594,6 +1920,7 @@ paths:
             type: array
             items:
               type: string
+              maxItems: 50
           style: simple
         - in: path
           name: context
@@ -1655,6 +1982,7 @@ paths:
             type: array
             items:
               type: string
+              maxItems: 50
           style: simple
         
       responses:
@@ -1707,6 +2035,7 @@ paths:
             type: array
             items:
               type: string
+              maxItems: 50
           style: simple
       
       responses:
@@ -1762,6 +2091,7 @@ paths:
             type: array
             items:
               type: string
+              maxItems: 50
           style: simple
       
       responses:
@@ -1806,7 +2136,6 @@ paths:
 
 components:
   responses:
-    
 
     BadRequest:
       description: Forma della richiesta non conforme alla specifica
@@ -1864,6 +2193,7 @@ components:
         - ipacode
         - officecode
         - version
+        - id
         - description
       properties:
         ipacode:
@@ -1880,7 +2210,11 @@ components:
           pattern: "[0-9]{2}.[0-9]{2}.[0-9]{2}"
         description:
             title: descrizione dell'amministrazione
-            type: string 
+            type: string
+        id:
+          title: identificativo SSU dell'amministrazione
+          type: string
+          minLength: 1
 
     Times:
       description: tempi amministrativi dell'istanza
@@ -2008,6 +2342,46 @@ components:
         end: 2024-12-31
         state: Active
 
+    AdministrationEntity:
+      description: struttura di risorsa generica con id,versione e descrizione
+      allOf:
+        - type: object
+          required:
+            - id
+            - description
+          properties:
+           id:
+              title: identificativo univoco della risorsa
+              type: string
+           version:
+             title: version della risorsa
+             type: string
+           description:
+             title: descrizione della risorsa
+             type: string
+           start:          
+             title: data inizio intervallo di validità della versione
+             type: string
+             format: date
+           end:          
+             title: data fine intervallo di validità della versione
+             type: string
+             format: date
+           state:
+             title: stato di validità della versione
+             type: string
+             enum:
+               - Active
+               - Not Active
+               - Revocated
+      example:
+        id: 1
+        version: 1.0.0
+        description: Entità generica con id,versione, descrizione
+        start: 2024-01-01
+        end: 2024-12-31
+        state: Active
+
     DeskEntity:
       description: struttura di risorsa generica con id,versione e descrizione
       allOf:
@@ -2029,6 +2403,41 @@ components:
         state: Active
         context: SUAP
 
+    DocumentClassification:
+      description: struttura oggetto classificazione dei documenti
+      type: object
+      required:
+        - coding
+        - class_code
+        - class_description
+        - typology_code
+        - typology_description
+      properties:
+        coding:
+          title: Codifica della classificazione associata ad un documento
+          type: string
+          pattern: "C[0-9]{1,2}_[a-z]"
+        class_code:
+          title: Codice della Classe di un documento
+          type: string
+          pattern: "C[0-9]{1,2}"
+        class_description:
+          title: Descrizione della Classe di un documento
+          type: string
+        typology_code:
+          title: Codice della Tipologia di un documento
+          type: string
+          pattern: "[a-z]"
+        typology_description:
+          title: Descrizione della Tipologia di un documento
+          type: string
+      example:
+        coding: "C2_b"
+        class_code: "C2"
+        class_description: "AUTORIZZAZIONI, PERMESSI E AUTOCERTIFICAZIONI"
+        typology_code: "b"
+        typology_description: "Autorizzazioni"
+
     DocumentEntity:
       allOf:
         - $ref: "#/components/schemas/GenericEntity"
@@ -2047,6 +2456,22 @@ components:
         description: Entità id,versione, descrizione e tipo strutturato/non strutturato
         type: structured 
     
+    DocumentEntityClassified:
+      type: object
+      allOf:
+        - $ref: "#/components/schemas/DocumentEntity"
+        - type: object
+      properties:
+        document_classification_coding:
+          type: string
+          pattern: "C[0-9]{1,2}_[a-z]"
+      example:
+        id: 1
+        version: 1.0.0
+        description: Entità id,versione, descrizione e tipo strutturato/non strutturato
+        type: structured 
+        document_classification_coding: C1_a
+
     ResourceEntity:
       allOf:
         - $ref: "#/components/schemas/GenericEntity"

--- a/OpenAPI/ri_to_bo.yaml
+++ b/OpenAPI/ri_to_bo.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 
 info:
-    title: RegistroImprese to BackOffice SUAP
+    title: RegistroImprese to BackOffice SUE
 
     version: 1.0.0
 
@@ -186,8 +186,24 @@ components:
                 uuid:
                     title: UUID chiave del CUI
                     type: string
+        
+        Tag:
+            description: struttura oggetto Tag
+            type: object
+            required:
+              - tag_key
+              - tag_value
+            properties:
+              tag_key:
+                title: Chiave del Tag di classificazione associato ad un documento
+                type: string
+                example: "SottoProcedimento"
+              tag_value:
+                title: Valore del Tag di classificazione associato ad un documento
+                type: string
+                example: "AUA"
 
-        InstanceIndex:
+        InstanceIndexFII:
             type: array
             description: indice istanza
             items:
@@ -197,6 +213,7 @@ components:
                 - ref
                 - description
                 - resource_id
+                - document_classification_coding
                 - hash
                 - alg_hash
                 properties:
@@ -212,10 +229,37 @@ components:
                         title: descrizione della risorsa
                         type: string
                         minLength: 1
+                    filename:                      
+                        title: filename della risorsa documento correlata all'evento notificato
+                        type: string
+                        minLength: 1
+                    file_size:
+                        description: Dimensione del file.
+                        type: integer
+                    mime_type:
+                        type: string
+                        enum: 
+                            - application/pdf
+                            - application/xml
+                            - application/pkcs7-mime
                     resource_id:                            
                         title: id della risorsa, univoco per erogatore e CUI.UUID
                         type: string
                         minLength: 1
+                    document_classification_coding:
+                      title: Codifica della classificazione associata ad un documento
+                      description: La classificazione viene recuperata dal Catalogo SSU, tuttavia, resta in capo al Back-Office la responsabilità di tale associazione e, qualora venga ritenuto opportuno, può ad ogni modo apportare una correzione. I valori ammissibili sono recuperabili al path catalogo-ssu_meta/document_classifications.
+                      type: string
+                      pattern: "C[0-9]{1,2}_[a-z]"
+                    tags: 
+                      description: Tag associati al documento.
+                      type: array
+                      items:
+                          $ref: '#/components/schemas/Tag'
+                    validity:
+                      description: Validità del documento espressa in formato "date".
+                      type: string
+                      format: date
                     hash:                            
                         title: hash dell'elemento dell'istanza relativo al procedimento
                         type: string
@@ -227,6 +271,7 @@ components:
                         - S256
                         - S384
                         - S512
+
         Resources: 
             type: array
             description: array delle risorse
@@ -260,152 +305,342 @@ components:
                         title: descrizione della risorsa
                         type: string
                         minLength: 1
-        GeneralIndex:
+
+        GeneralIndexFII:
             type: array
             description: indice allegati trasversali (da utilizzare solo in caso di Edilizia Produttiva avviata direttamente sul SUE)
             minItems: 0
             uniqueItems: true
             items:
-                anyOf:
-                    - $ref: '#/components/schemas/ricevuta_xml'
-                    - $ref: '#/components/schemas/ricevuta_pdf'
-                    - $ref: '#/components/schemas/suap_xml'
-                    - $ref: '#/components/schemas/suap_pdf'
-                            
-        ricevuta_xml:
-                      type: object
-                      description: il presente documento è validato con l’XML Schema definito ai sensi dell’allegato al DPR 160/2010
-                        precedente alla variazione DECRETO 12 novembre 2021 recuperabile nella sezione regole “Regole tecniche”
-                        del portale impresainungiorno
-                        (https://www.impresainungiorno.gov.it/documents/155997/157492/SUAP-ricevuta-1.1.4.xsd/58b9d8e8-2b76-4b8b-adee-0cf9c2bbe04a)
-                      additionalProperties: false
-                      required:
-                        - name
-                        - mime_type
-                        - resource_id
-                        - hash
-                        - alg_hash
-                      properties:
-                        name:
-                          type: string
-                          enum:
-                            - RICEVUTA_XML
-                        mime_type:
-                          type: string
-                          enum:
-                            - application/xml
-                            - application/pkcs7-mime
-                        resource_id:
-                          type: string
-                          minLength: 1
-                        hash:
-                          type: string
-                          minLength: 1
-                        alg_hash:
-                          type: string
-                          enum:
-                            - S256
-                            - S384
-                            - S512
-        ricevuta_pdf:
-                      type: object
-                      additionalProperties: false
-                      required:
-                        - name
-                        - mime_type
-                        - resource_id
-                        - hash
-                        - alg_hash
-                      properties:
-                        name:
-                          type: string
-                          enum:
-                            - RICEVUTA_PDF
-                        mime_type:
-                          type: string
-                          enum:
-                            - application/pdf
-                            - application/pkcs7-mime
-                        resource_id:
-                          type: string
-                          minLength: 1
-                        hash:
-                          type: string
-                          minLength: 1
-                        alg_hash:
-                          type: string
-                          enum:
-                            - S256
-                            - S384
-                            - S512
-        suap_xml:
-                      type: object
-                      description: il presente documento è validato con l’XML Schema definito ai sensi dell’allegato al DPR 160/2010
-                        precedente alla variazione DECRETO 12 novembre 2021 recuperabile nella sezione regole “Regole tecniche”
-                        del portale impresainungiorno
-                        (https://www.impresainungiorno.gov.it/documents/155997/157492/pratica_suap-2.0.0.xsd/74b7ffb2-fe01-41c6-b210-be36139923e4 , 
-                        https://www.impresainungiorno.gov.it/documents/155997/157492/Definizione+delle+strutture+dati+elementari+di+impresainungiorno.xsd/43929369-48f0-4b7b-883e-f57dc5cdd41e)
-                      additionalProperties: false
-                      required:
-                        - name
-                        - mime_type
-                        - resource_id
-                        - hash
-                        - alg_hash
-                      properties:
-                        name:
-                          type: string
-                          enum:
-                            - SUAP_XML
-                        mime_type:
-                          type: string
-                          enum:
-                            - application/xml
-                            - application/pkcs7-mime
-                        resource_id:
-                          type: string
-                          minLength: 1
-                        hash:
-                          type: string
-                          minLength: 1
-                        alg_hash:
-                          type: string
-                          enum:
-                            - S256
-                            - S384
-                            - S512
-        suap_pdf:
-                      type: object
-                      additionalProperties: false
-                      required:
-                        - name
-                        - mime_type
-                        - resource_id
-                        - hash
-                        - alg_hash
-                      properties:
-                        name:
-                          type: string
-                          enum:
-                            - SUAP_PDF
-                        mime_type:
-                          type: string
-                          enum:
-                            - application/pdf
-                            - application/pkcs7-mime
-                        resource_id:
-                          type: string
-                          minLength: 1
-                        hash:
-                          type: string
-                          minLength: 1
-                        alg_hash:
-                          type: string
-                          enum:
-                            - S256
-                            - S384
-                            - S512
+              anyOf:
+                - $ref: '#/components/schemas/ricevuta_xml_fii'
+                - $ref: '#/components/schemas/ricevuta_pdf_fii'
+                - $ref: '#/components/schemas/suap_xml_fii'
+                - $ref: '#/components/schemas/suap_pdf_fii'
+                - $ref: '#/components/schemas/suap_rea_start_xml_fii'
+                - $ref: '#/components/schemas/suap_rea_update_xml_fii'
 
+        ricevuta_xml_fii:
+            type: object
+            description: il presente documento è validato con l’XML Schema definito ai sensi dell’allegato al DPR 160/2010
+              precedente alla variazione DECRETO 12 novembre 2021 recuperabile nella sezione regole “Regole tecniche”
+              del portale impresainungiorno
+              (https://www.impresainungiorno.gov.it/documents/155997/157492/SUAP-ricevuta-1.1.4.xsd/58b9d8e8-2b76-4b8b-adee-0cf9c2bbe04a)
+            additionalProperties: false
+            required:
+              - name
+              - mime_type
+              - resource_id
+              - document_classification_coding
+              - hash
+              - alg_hash
+            properties:
+              name:
+                type: string
+                enum:
+                  - RICEVUTA_XML
+              mime_type:
+                type: string
+                enum:
+                  - application/xml
+                  - application/pkcs7-mime
+              resource_id:
+                type: string
+                minLength: 1
+              document_classification_coding:
+                  title: Codifica della classificazione associata ad un documento
+                  description: La classificazione viene recuperata dal Catalogo SSU, tuttavia, resta in capo al Back-Office la responsabilità di tale associazione e, qualora venga ritenuto opportuno, può ad ogni modo apportare una correzione. I valori ammissibili sono recuperabili al path catalogo-ssu_meta/document_classifications.
+                  type: string
+                  pattern: "C[0-9]{1,2}_[a-z]"
+              tags: 
+                description: Tag associati al documento.
+                type: array
+                items:
+                    $ref: '#/components/schemas/Tag'
+              hash:
+                type: string
+                minLength: 1
+              alg_hash:
+                type: string
+                enum:
+                  - S256
+                  - S384
+                  - S512
+
+        ricevuta_pdf_fii:
+            type: object
+            additionalProperties: false
+            required:
+              - name
+              - mime_type
+              - resource_id
+              - document_classification_coding
+              - hash
+              - alg_hash
+            properties:
+              name:
+                type: string
+                enum:
+                  - RICEVUTA_PDF
+              mime_type:
+                type: string
+                enum:
+                  - application/pdf
+                  - application/pkcs7-mime
+              resource_id:
+                type: string
+                minLength: 1
+              document_classification_coding:
+                  title: Codifica della classificazione associata ad un documento
+                  description: La classificazione viene recuperata dal Catalogo SSU, tuttavia, resta in capo al Back-Office la responsabilità di tale associazione e, qualora venga ritenuto opportuno, può ad ogni modo apportare una correzione. I valori ammissibili sono recuperabili al path catalogo-ssu_meta/document_classifications.
+                  type: string
+                  pattern: "C[0-9]{1,2}_[a-z]"
+              tags: 
+                description: Tag associati al documento.
+                type: array
+                items:
+                    $ref: '#/components/schemas/Tag'
+              hash:
+                type: string
+                minLength: 1
+              alg_hash:
+                type: string
+                enum:
+                  - S256
+                  - S384
+                  - S512
+
+        suap_xml_fii:
+            type: object
+            description: il presente documento è validato con l’XML Schema definito ai sensi dell’allegato al DPR 160/2010
+              precedente alla variazione DECRETO 12 novembre 2021 recuperabile nella sezione regole “Regole tecniche”
+              del portale impresainungiorno
+              (https://www.impresainungiorno.gov.it/documents/155997/157492/pratica_suap-2.0.0.xsd/74b7ffb2-fe01-41c6-b210-be36139923e4 , 
+              https://www.impresainungiorno.gov.it/documents/155997/157492/Definizione+delle+strutture+dati+elementari+di+impresainungiorno.xsd/43929369-48f0-4b7b-883e-f57dc5cdd41e)
+            additionalProperties: false
+            required:
+              - name
+              - mime_type
+              - resource_id
+              - document_classification_coding
+              - hash
+              - alg_hash
+            properties:
+              name:
+                type: string
+                enum:
+                  - SUAP_XML
+              mime_type:
+                type: string
+                enum:
+                  - application/xml
+                  - application/pkcs7-mime
+              resource_id:
+                type: string
+                minLength: 1
+              document_classification_coding:
+                  title: Codifica della classificazione associata ad un documento
+                  description: La classificazione viene recuperata dal Catalogo SSU, tuttavia, resta in capo al Back-Office la responsabilità di tale associazione e, qualora venga ritenuto opportuno, può ad ogni modo apportare una correzione. I valori ammissibili sono recuperabili al path catalogo-ssu_meta/document_classifications.
+                  type: string
+                  pattern: "C[0-9]{1,2}_[a-z]"
+              tags: 
+                description: Tag associati al documento.
+                type: array
+                items:
+                    $ref: '#/components/schemas/Tag'
+              hash:
+                type: string
+                minLength: 1
+              alg_hash:
+                type: string
+                enum:
+                  - S256
+                  - S384
+                  - S512
+
+        suap_pdf_fii:
+            type: object
+            additionalProperties: false
+            required:
+              - name
+              - mime_type
+              - resource_id
+              - document_classification_coding
+              - hash
+              - alg_hash
+            properties:
+              name:
+                type: string
+                enum:
+                  - SUAP_PDF
+              mime_type:
+                type: string
+                enum:
+                  - application/pdf
+                  - application/pkcs7-mime
+              resource_id:
+                type: string
+                minLength: 1
+              document_classification_coding:
+                  title: Codifica della classificazione associata ad un documento
+                  description: La classificazione viene recuperata dal Catalogo SSU, tuttavia, resta in capo al Back-Office la responsabilità di tale associazione e, qualora venga ritenuto opportuno, può ad ogni modo apportare una correzione. I valori ammissibili sono recuperabili al path catalogo-ssu_meta/document_classifications.
+                  type: string
+                  pattern: "C[0-9]{1,2}_[a-z]"
+              tags: 
+                description: Tag associati al documento.
+                type: array
+                items:
+                    $ref: '#/components/schemas/Tag'
+              hash:
+                type: string
+                minLength: 1
+              alg_hash:
+                type: string
+                enum:
+                  - S256
+                  - S384
+                  - S512
+
+        suap_rea_start_xml_fii:
+            type: object
+            description: il presente documento è validato con l’XML Schema definito ai sensi dell’allegato al DPR 160/2010
+              precedente alla variazione DECRETO 12 novembre 2021 recuperabile nella sezione regole “Regole tecniche”
+              del portale impresainungiorno
+              (https://www.impresainungiorno.gov.it/documents/155997/157488/suap-rea-1.1.1.xsd/2094658b-c981-4795-8d18-ffa91fa97069)
+            additionalProperties: false
+            required:
+              - name
+              - mime_type
+              - resource_id
+              - document_classification_coding
+              - hash
+              - alg_hash
+            properties:
+              name:
+                type: string
+                enum:
+                  - SUAP_REA_START_XML
+              mime_type:
+                type: string
+                enum:
+                  - application/xml
+                  - application/pkcs7-mime
+              resource_id:
+                type: string
+                minLength: 1
+              document_classification_coding:
+                  title: Codifica della classificazione associata ad un documento
+                  description: La classificazione viene recuperata dal Catalogo SSU, tuttavia, resta in capo al Back-Office la responsabilità di tale associazione e, qualora venga ritenuto opportuno, può ad ogni modo apportare una correzione. I valori ammissibili sono recuperabili al path catalogo-ssu_meta/document_classifications.
+                  type: string
+                  pattern: "C[0-9]{1,2}_[a-z]"
+              tags: 
+                description: Tag associati al documento.
+                type: array
+                items:
+                    $ref: '#/components/schemas/Tag'
+              hash:
+                type: string
+                minLength: 1
+              alg_hash:
+                type: string
+                enum:
+                  - S256
+                  - S384
+                  - S512
+
+        suap_rea_update_xml_fii:
+            type: object
+            description: il presente documento è validato con l’XML Schema definito ai sensi dell’allegato al DPR 160/2010
+              precedente alla variazione DECRETO 12 novembre 2021 recuperabile nella sezione regole “Regole tecniche”
+              del portale impresainungiorno
+              (https://www.impresainungiorno.gov.it/documents/155997/157488/suap-rea-1.1.1.xsd/2094658b-c981-4795-8d18-ffa91fa97069)
+            additionalProperties: false
+            required:
+              - name
+              - mime_type
+              - resource_id
+              - document_classification_coding
+              - hash
+              - alg_hash
+            properties:
+              name:
+                type: string
+                enum:
+                  - SUAP_REA_UPDATE_XML
+              mime_type:
+                type: string
+                enum:
+                  - application/xml
+                  - application/pkcs7-mime
+              resource_id:
+                type: string
+                minLength: 1
+              document_classification_coding:
+                  title: Codifica della classificazione associata ad un documento
+                  description: La classificazione viene recuperata dal Catalogo SSU, tuttavia, resta in capo al Back-Office la responsabilità di tale associazione e, qualora venga ritenuto opportuno, può ad ogni modo apportare una correzione. I valori ammissibili sono recuperabili al path catalogo-ssu_meta/document_classifications.
+                  type: string
+                  pattern: "C[0-9]{1,2}_[a-z]"
+              tags: 
+                description: Tag associati al documento.
+                type: array
+                items:
+                    $ref: '#/components/schemas/Tag'
+              hash:
+                type: string
+                minLength: 1
+              alg_hash:
+                type: string
+                enum:
+                  - S256
+                  - S384
+                  - S512
+  
+        suap_rea_end_fii:
+            type: object
+            additionalProperties: false
+            required:
+              - name
+              - mime_type
+              - resource_id
+              - document_classification_coding
+              - hash
+              - alg_hash
+            properties:
+              name:
+                type: string
+                enum:
+                  - SUAP_REA_UPDATE_XML
+              mime_type:
+                type: string
+                enum:
+                  - application/xml
+                  - application/pkcs7-mime
+              resource_id:
+                title: id della risorsa documento correlata all'xml del rea_end
+                type: string
+                minLength: 1
+              document_classification_coding:
+                  title: Codifica della classificazione associata ad un documento
+                  description: La classificazione viene recuperata dal Catalogo SSU, tuttavia, resta in capo al Back-Office la responsabilità di tale associazione e, qualora venga ritenuto opportuno, può ad ogni modo apportare una correzione. I valori ammissibili sono recuperabili al path catalogo-ssu_meta/document_classifications.
+                  type: string
+                  pattern: "C[0-9]{1,2}_[a-z]"
+              tags: 
+                description: Tag associati al documento.
+                type: array
+                items:
+                    $ref: '#/components/schemas/Tag'
+              hash:
+                  title: hash risorsa
+                  type: string
+                  minLength: 1
+              alg_hash:
+                  title: algoritmo hash applicato
+                  type: string
+                  enum:
+                  - S256
+                  - S384
+                  - S512
+        
         Error:
             type: object
             description: codice e descrizione condizione di errore
@@ -423,19 +658,19 @@ components:
                 - cui
                 - instance_descriptor_version
                 - instance_status
-                - instance_index
+                - instance_index_fii
             type: object
             properties:
                 cui:
                     $ref: "#/components/schemas/cui"
                 instance_descriptor_version:
                     type: string
-                instance_index:
-                    $ref: "#/components/schemas/InstanceIndex"
+                instance_index_fii:
+                    $ref: "#/components/schemas/InstanceIndexFII"
                 resources:
                     oneOf:
                         - $ref: "#/components/schemas/Resources"
-                        - $ref: "#/components/schemas/GeneralIndex"
+                        - $ref: "#/components/schemas/GeneralIndexFII"
 
         NotifyMessage:
             type: object
@@ -456,6 +691,8 @@ components:
                         - end_by_integration_times_expired
                         - end_by_conformation_times_expired
                         - end_by_submitter_cancel_requested
+                resource_rea_end:
+                    $ref: "#/components/schemas/suap_rea_end_fii" 
 
         TransferOutcomeNotifyMessage:
             type: object


### PR DESCRIPTION
  Questa Pull Request introduce il porting della Classificazione Documentale (secondo la Tassonomia definita in
  Allegato A - Art.5 comma 1 Decreto 17 settembre 2024 n.159 e ss.mm.ii.) e il supporto ai Tag dei documenti
  all'interno delle specifiche OpenAPI del Catalogo Meta SSU ( catalogo-ssu_meta.yaml ) e dell'interfaccia Registro
  Imprese to Back-Office ( ri_to_bo.yaml ).

  Oltre all'integrazione delle classificazioni, la PR include importanti razionalizzazioni degli schemi per il
  Fascicolo di Impresa ( FII ), vincoli di cardinalità sulle query bulk ( maxItems: 50 ), e correzioni minori.

Dettaglio delle Modifiche per File

**1. catalogo-ssu_meta.yaml**

Nuovi Endpoint per la Classificazione Documentale e Tag:
      •  GET /document_classifications : recupero dell'elenco delle classificazioni documentali filtrabili via query
      string ( coding ,  class_code ,  class_description ,  typology_code ,  typology_description ).
      •  GET /general_index_classifications/{name} : recupero della classificazione associata a un documento del
      General-Index.
      •  GET /document_classification/form/{form_id_list} : recupero delle classificazioni associate a liste di Form (
      DocumentEntityClassified ).
      •  GET /document_classification/attachment/{attachment_id_list} : recupero delle classificazioni associate a
      liste di Allegati ( DocumentEntityClassified ).
      •  GET /tags : recupero dell'elenco dei tag dei procedimenti.

Nuovi Schemi nei Components:
      •  DocumentClassification : definizione della struttura per codifica ( pattern: "C[0-9]{1,2}_[a-z]" ), classe e
      tipologia.
      •  DocumentEntityClassified : estensione di  DocumentEntity  con l'attributo  document_classification_coding .
      •  AdministrationEntity : schema generico per la rappresentazione dell'amministrazione (id, versione, descrizione,
      date validità e stato).

Vincoli e Bugfix:
      • Inserito  maxItems: 50  per la validazione delle liste nei parametri di path/query (es.  id_proceeding_list , 
      id_component_list ,  id_form_list ,  id_attachment_list , ecc.).
      • Reso opzionale ( required: false ) il parametro  lifeevent  nell'endpoint  /typologies-lifeevents/{context} .
      • Aggiunto il campo  id  allo schema  ComponentEntity .
      • Allineati i riferimenti degli schemi in  /proceeding-third-party-systems-by-administration/  (passando a 
      AdministrationEntity ).

**2. ri_to_bo.yaml**

Porting Classificazione Documentale e Tag (FII):
      • Nuovo Schema  Tag : struttura con  tag_key  e  tag_value  per associare metadati/tag ai documenti.
      • Ristrutturazione Schemi Indice Istanza ( InstanceIndexFII  e  GeneralIndexFII ):
          • Aggiunti i campi  document_classification_coding  e l'array di  tags  agli indici dei documenti.
          • Aggiunti attributi di dettaglio ai documenti:  filename ,  file_size ,  mime_type ,  validity .
          • Nuove definizioni specifiche per documenti FII:  ricevuta_xml_fii ,  ricevuta_pdf_fii ,  suap_xml_fii ,
          suap_pdf_fii ,  suap_rea_start_xml_fii ,  suap_rea_update_xml_fii  e  suap_rea_end_fii .

Aggiornamento Messaggi di Notifica:
      • Aggiornato  ResourceIndexFII  per fare riferimento ai nuovi schemi  InstanceIndexFII  e  GeneralIndexFII .
      • Aggiornato  NotifyMessage  aggiungendo la risorsa  resource_rea_end  ( suap_rea_end_fii ).

Intestazioni:
      • Aggiornato il titolo della specifica in  RegistroImprese to BackOffice SUE .